### PR TITLE
TG-4385 | Fix CircleCI build 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ jobs:
           name: Start Twingate
           command: |
             # install
+            sudo apt install -yq ca-certificates
             echo "deb [trusted=yes] https://packages.twingate.com/apt/ /" | sudo tee /etc/apt/sources.list.d/twingate.list
             sudo apt update -yq
             sudo apt install -yq twingate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ jobs:
           name: Start Twingate
           command: |
             # install
+            sudo apt update -yq
             sudo apt install -yq ca-certificates
             echo "deb [trusted=yes] https://packages.twingate.com/apt/ /" | sudo tee /etc/apt/sources.list.d/twingate.list
             sudo apt update -yq


### PR DESCRIPTION
> JIRA Ticket URL: TG-4385

Source validation for Twingate repo fails as the machine doesn't have the latest CA certificate

## Changes 
- Added a step to install the latest CA certificates 